### PR TITLE
feat: implement visual prompt builder with customizable sections and export options

### DIFF
--- a/app/prompt/page.tsx
+++ b/app/prompt/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { PromptCanvas } from '../../components/prompts/prompt-canvas';
+
+export default function PromptBuilderPage() {
+  return <PromptCanvas />;
+}
+
+export const metadata = {
+  title: 'Visual Prompt Builder | PowerPrompt POC',
+  description: 'Create structured, hierarchical prompts with visual components and instant XML/Markdown export.',
+}; 

--- a/components/prompts/connection-lines.tsx
+++ b/components/prompts/connection-lines.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import React from 'react';
+import type { Connection } from '../../types/prompt-builder';
+
+interface ConnectionLinesProps {
+  connections: Connection[];
+  containerRef: React.RefObject<HTMLDivElement>;
+}
+
+export function ConnectionLines({ connections, containerRef }: ConnectionLinesProps) {
+  if (!containerRef.current || connections.length === 0) {
+    return null;
+  }
+
+  return (
+    <svg
+      className="absolute top-0 left-0 pointer-events-none z-0"
+      style={{
+        width: '100%',
+        height: '100%',
+      }}
+    >
+      <defs>
+        <marker
+          id="arrowhead"
+          markerWidth="10"
+          markerHeight="7"
+          refX="9"
+          refY="3.5"
+          orient="auto"
+        >
+          <polygon
+            points="0 0, 10 3.5, 0 7"
+            fill="hsl(var(--border))"
+            opacity="0.6"
+          />
+        </marker>
+      </defs>
+      
+      {connections.map((connection) => (
+        <g key={connection.id}>
+          {/* Main connection line */}
+          <path
+            d={`M ${connection.points[0].x} ${connection.points[0].y} 
+                L ${connection.points[1].x} ${connection.points[1].y}`}
+            stroke="hsl(var(--border))"
+            strokeWidth="2"
+            strokeDasharray="5,5"
+            fill="none"
+            opacity="0.6"
+            markerEnd="url(#arrowhead)"
+          />
+          
+          {/* Connection points */}
+          <circle
+            cx={connection.points[0].x}
+            cy={connection.points[0].y}
+            r="3"
+            fill="hsl(var(--primary))"
+            opacity="0.8"
+          />
+          <circle
+            cx={connection.points[1].x}
+            cy={connection.points[1].y}
+            r="3"
+            fill="hsl(var(--primary))"
+            opacity="0.8"
+          />
+        </g>
+      ))}
+    </svg>
+  );
+} 

--- a/components/prompts/export-panel.tsx
+++ b/components/prompts/export-panel.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Copy, Check, Code, FileText, ChevronDown } from 'lucide-react';
+import { Button } from '../ui/button';
+import type { ExportFormat } from '../../types/prompt-builder';
+
+interface ExportPanelProps {
+  exportData: ExportFormat;
+  onExport: () => ExportFormat;
+}
+
+export function ExportPanel({ exportData }: ExportPanelProps) {
+  const [copiedXml, setCopiedXml] = useState(false);
+  const [copiedMarkdown, setCopiedMarkdown] = useState(false);
+  const [isXmlCollapsed, setIsXmlCollapsed] = useState(false);
+  const [isMarkdownCollapsed, setIsMarkdownCollapsed] = useState(false);
+
+  const copyToClipboard = async (content: string, type: 'xml' | 'markdown') => {
+    if (!content.trim()) {
+      alert('No content to copy. Please add some content to your boxes.');
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(content);
+      if (type === 'xml') {
+        setCopiedXml(true);
+        setTimeout(() => setCopiedXml(false), 2000);
+      } else {
+        setCopiedMarkdown(true);
+        setTimeout(() => setCopiedMarkdown(false), 2000);
+      }
+    } catch (err) {
+      console.error('Failed to copy:', err);
+      // Fallback for browsers without clipboard API
+      const textArea = document.createElement('textarea');
+      textArea.value = content;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textArea);
+      
+      if (type === 'xml') {
+        setCopiedXml(true);
+        setTimeout(() => setCopiedXml(false), 2000);
+      } else {
+        setCopiedMarkdown(true);
+        setTimeout(() => setCopiedMarkdown(false), 2000);
+      }
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Quick Copy Buttons */}
+      <div className="flex gap-2">
+        <Button
+          onClick={() => copyToClipboard(exportData.xml, 'xml')}
+          variant="default"
+          size="sm"
+          className="flex-1 text-xs"
+        >
+          {copiedXml ? <Check className="w-3 h-3 mr-1" /> : <Copy className="w-3 h-3 mr-1" />}
+          {copiedXml ? 'Copied!' : 'Copy XML'}
+        </Button>
+        <Button
+          onClick={() => copyToClipboard(exportData.markdown, 'markdown')}
+          variant="outline"
+          size="sm"
+          className="flex-1 text-xs"
+        >
+          {copiedMarkdown ? <Check className="w-3 h-3 mr-1" /> : <Copy className="w-3 h-3 mr-1" />}
+          {copiedMarkdown ? 'Copied!' : 'Copy MD'}
+        </Button>
+      </div>
+
+      {/* XML Export */}
+      <div className="bg-card rounded-lg border border-border p-3">
+        <div className="flex items-center justify-between mb-2">
+          <div 
+            className="flex items-center gap-1 cursor-pointer hover:opacity-80 transition-opacity"
+            onClick={() => setIsXmlCollapsed(!isXmlCollapsed)}
+          >
+            <ChevronDown 
+              className={`w-3 h-3 text-foreground transition-transform duration-200 ${
+                isXmlCollapsed ? '-rotate-90' : 'rotate-0'
+              }`}
+            />
+            <Code className="w-3 h-3 text-foreground" />
+            <h4 className="text-sm font-medium text-foreground">XML Preview</h4>
+          </div>
+        </div>
+        
+        {!isXmlCollapsed && (
+          <div className="bg-muted rounded-md p-2 border border-border">
+            <pre className="text-xs text-foreground whitespace-pre-wrap font-mono leading-relaxed max-h-48 overflow-y-auto">
+              {exportData.xml || 'No content to export. Add content to your boxes above.'}
+            </pre>
+          </div>
+        )}
+      </div>
+
+      {/* Markdown Export */}
+      <div className="bg-card rounded-lg border border-border p-3">
+        <div className="flex items-center justify-between mb-2">
+          <div 
+            className="flex items-center gap-1 cursor-pointer hover:opacity-80 transition-opacity"
+            onClick={() => setIsMarkdownCollapsed(!isMarkdownCollapsed)}
+          >
+            <ChevronDown 
+              className={`w-3 h-3 text-foreground transition-transform duration-200 ${
+                isMarkdownCollapsed ? '-rotate-90' : 'rotate-0'
+              }`}
+            />
+            <FileText className="w-3 h-3 text-foreground" />
+            <h4 className="text-sm font-medium text-foreground">Markdown Preview</h4>
+          </div>
+        </div>
+        
+        {!isMarkdownCollapsed && (
+          <div className="bg-muted rounded-md p-2 border border-border">
+            <pre className="text-xs text-foreground whitespace-pre-wrap font-mono leading-relaxed max-h-48 overflow-y-auto">
+              {exportData.markdown || 'No content to export. Add content to your boxes above.'}
+            </pre>
+          </div>
+        )}
+      </div>
+
+      <div className="text-xs text-muted-foreground text-center">
+        💡 <strong>Tip:</strong> XML format works better with LLMs
+      </div>
+    </div>
+  );
+} 

--- a/components/prompts/prompt-box.tsx
+++ b/components/prompts/prompt-box.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import React from 'react';
+import { X, Plus, Grip } from 'lucide-react';
+import { Button } from '../ui/button';
+import type { PromptBox } from '../../types/prompt-builder';
+
+interface PromptBoxProps {
+  box: PromptBox;
+  allTags: string[];
+  onUpdate: (id: string, field: 'tag' | 'content', value: string) => void;
+  onRemove: (id: string) => void;
+  onAddChild: (parentId: string) => void;
+  canRemove: boolean;
+  isSelected?: boolean;
+  onSelect?: (id: string) => void;
+}
+
+export function PromptBox({
+  box,
+  allTags,
+  onUpdate,
+  onRemove,
+  onAddChild,
+  canRemove,
+  isSelected,
+  onSelect
+}: PromptBoxProps) {
+  const levelColors = [
+    'border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/20',
+    'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/20',
+    'border-purple-200 bg-purple-50 dark:border-purple-800 dark:bg-purple-950/20',
+    'border-orange-200 bg-orange-50 dark:border-orange-800 dark:bg-orange-950/20',
+    'border-pink-200 bg-pink-50 dark:border-pink-800 dark:bg-pink-950/20'
+  ];
+
+  const colorClass = levelColors[box.position.level % levelColors.length];
+  
+  return (
+    <div
+      className={`absolute z-10 transition-all duration-200 ${
+        isSelected ? 'ring-2 ring-primary' : ''
+      }`}
+      style={{
+        left: box.position.x,
+        top: box.position.y,
+        width: '240px' // Reduced from 280px to fit better in narrow layout
+      }}
+      onClick={() => onSelect?.(box.id)}
+    >
+      <div className={`bg-card rounded-lg border-2 ${colorClass} shadow-sm hover:shadow-md transition-shadow`}>
+        {/* Header */}
+        <div className="flex items-center gap-1 p-2 pb-1">
+          <div className="cursor-grab active:cursor-grabbing">
+            <Grip className="w-3 h-3 text-muted-foreground" />
+          </div>
+          
+          <select
+            value={box.tag}
+            onChange={(e) => onUpdate(box.id, 'tag', e.target.value)}
+            className="flex-1 px-1 py-0.5 border border-input rounded focus:outline-none focus:ring-1 focus:ring-ring bg-background text-foreground font-mono text-xs uppercase font-medium"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {allTags.map((tag) => (
+              <option key={tag} value={tag}>
+                {tag.toUpperCase()}
+              </option>
+            ))}
+          </select>
+
+          <div className="flex items-center gap-0.5">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                onAddChild(box.id);
+              }}
+              className="p-0.5 h-5 w-5 hover:bg-primary/10"
+              title="Add child box"
+            >
+              <Plus className="w-2.5 h-2.5" />
+            </Button>
+            
+            {canRemove && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRemove(box.id);
+                }}
+                className="p-0.5 h-5 w-5 hover:bg-destructive/10 hover:text-destructive"
+                title="Remove box"
+              >
+                <X className="w-2.5 h-2.5" />
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="px-2 pb-2">
+          <textarea
+            value={box.content}
+            onChange={(e) => onUpdate(box.id, 'content', e.target.value)}
+            rows={2}
+            className="w-full px-2 py-1 border border-input rounded focus:outline-none focus:ring-1 focus:ring-ring bg-background text-foreground text-xs resize-y min-h-[60px]"
+            placeholder={`Enter ${box.tag} content...`}
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+
+        {/* Level indicator */}
+        <div className="absolute -left-1.5 top-1">
+          <div className="w-3 h-3 rounded-full bg-primary text-primary-foreground text-xs flex items-center justify-center font-bold">
+            {box.position.level}
+          </div>
+        </div>
+
+        {/* Connection points */}
+        <div className="absolute -right-1.5 top-1/2 transform -translate-y-1/2">
+          <div className="w-2 h-2 rounded-full bg-primary opacity-60"></div>
+        </div>
+        <div className="absolute -left-1.5 top-1/2 transform -translate-y-1/2">
+          <div className="w-2 h-2 rounded-full bg-primary opacity-60"></div>
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/components/prompts/prompt-canvas.tsx
+++ b/components/prompts/prompt-canvas.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import { Plus, RotateCcw, Eraser, Copy, Check, X } from 'lucide-react';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { StatsPanel } from './stats-panel';
+import { ExportPanel } from './export-panel';
+import { usePromptBuilder } from '../../hooks/use-prompt-builder';
+import { useStats } from '../../hooks/use-stats';
+
+export function PromptCanvas() {
+  const canvasRef = useRef<HTMLDivElement>(null);
+  const { state, allTags, actions } = usePromptBuilder();
+  const stats = useStats(state.boxes);
+  const [newTagInput, setNewTagInput] = React.useState('');
+  const [copiedXml, setCopiedXml] = useState(false);
+  const [copiedMarkdown, setCopiedMarkdown] = useState(false);
+
+  const exportData = actions.exportPrompt();
+
+  const copyToClipboard = async (content: string, type: 'xml' | 'markdown') => {
+    if (!content.trim()) {
+      alert('No content to copy. Please add some content to your sections.');
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(content);
+      if (type === 'xml') {
+        setCopiedXml(true);
+        setTimeout(() => setCopiedXml(false), 2000);
+      } else {
+        setCopiedMarkdown(true);
+        setTimeout(() => setCopiedMarkdown(false), 2000);
+      }
+    } catch (err) {
+      console.error('Failed to copy:', err);
+      // Fallback for browsers without clipboard API
+      const textArea = document.createElement('textarea');
+      textArea.value = content;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textArea);
+      
+      if (type === 'xml') {
+        setCopiedXml(true);
+        setTimeout(() => setCopiedXml(false), 2000);
+      } else {
+        setCopiedMarkdown(true);
+        setTimeout(() => setCopiedMarkdown(false), 2000);
+      }
+    }
+  };
+
+  const handleAddCustomTag = () => {
+    if (newTagInput.trim()) {
+      actions.addCustomTag(newTagInput.trim());
+      setNewTagInput('');
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleAddCustomTag();
+    }
+  };
+
+  return (
+    <div className="w-full space-y-4">
+      {/* Header */}
+      <div className="text-center space-y-1">
+        <h1 className="text-2xl font-bold text-foreground">Nitesh's Power Prompt Tool</h1>
+        <p className="text-sm text-muted-foreground">Create structured prompts with visual hierarchy</p>
+      </div>
+
+      {/* Stats Panel - Mobile First */}
+      <StatsPanel stats={stats} />
+
+      {/* Controls */}
+      <div className="bg-card rounded-md border border-border p-4">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-base font-semibold text-foreground">Controls</h3>
+          <div className="flex items-center gap-1">
+            <Button
+              onClick={actions.clearAllContent}
+              variant="outline"
+              size="sm"
+              className="text-xs px-2"
+            >
+              <Eraser className="w-3 h-3 mr-1" />
+              Clear
+            </Button>
+            <Button
+              onClick={actions.resetToDefault}
+              variant="outline"
+              size="sm"
+              className="text-xs px-2"
+            >
+              <RotateCcw className="w-3 h-3 mr-1" />
+              Reset
+            </Button>
+          </div>
+        </div>
+
+        {/* Tag Management */}
+        <div className="space-y-3">
+          <h4 className="text-sm font-medium text-foreground">Custom Tags</h4>
+          
+          {state.customTags.length > 0 && (
+            <div className="flex flex-wrap gap-1 mb-2">
+              {state.customTags.map((tag) => (
+                <div key={tag} className="flex items-center gap-1 bg-secondary text-secondary-foreground px-2 py-1 rounded-md text-xs">
+                  <span className="font-mono uppercase">{tag}</span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => actions.removeCustomTag(tag)}
+                    className="p-0 h-auto w-auto hover:bg-transparent"
+                  >
+                    <span className="text-xs">×</span>
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            <Input
+              value={newTagInput}
+              onChange={(e) => setNewTagInput(e.target.value)}
+              placeholder="Add custom tag..."
+              className="flex-1 text-sm h-8"
+              onKeyDown={handleKeyDown}
+            />
+            <Button
+              onClick={handleAddCustomTag}
+              variant="outline"
+              size="sm"
+              className="h-8 w-8 p-0"
+              disabled={!newTagInput.trim() || allTags.includes(newTagInput.trim().toLowerCase())}
+            >
+              <Plus className="w-3 h-3" />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Quick Copy Buttons */}
+      <div className="flex gap-2 mb-4">
+        <Button
+          onClick={() => copyToClipboard(exportData.xml, 'xml')}
+          variant="default"
+          size="sm"
+          className="flex-1 text-xs"
+        >
+          {copiedXml ? <Check className="w-3 h-3 mr-1" /> : <Copy className="w-3 h-3 mr-1" />}
+          {copiedXml ? 'Copied!' : 'Copy XML'}
+        </Button>
+        <Button
+          onClick={() => copyToClipboard(exportData.markdown, 'markdown')}
+          variant="outline"
+          size="sm"
+          className="flex-1 text-xs"
+        >
+          {copiedMarkdown ? <Check className="w-3 h-3 mr-1" /> : <Copy className="w-3 h-3 mr-1" />}
+          {copiedMarkdown ? 'Copied!' : 'Copy MD'}
+        </Button>
+      </div>
+
+      {/* Canvas */}
+      <div className="bg-card rounded-md border border-border p-2">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-base font-semibold text-foreground">Prompt Structure</h3>
+          <Button
+            onClick={() => actions.addBox()}
+            variant="outline"
+            size="sm"
+            className="text-xs px-2"
+          >
+            <Plus className="w-3 h-3 mr-1" />
+            Add Section
+          </Button>
+        </div>
+        
+        <div className="space-y-4">
+          {state.boxes.map((box, index) => (
+            <div key={box.id} className="space-y-3">
+              <div className="flex items-center gap-3">
+                <select
+                  value={box.tag}
+                  onChange={(e) => actions.updateBox(box.id, 'tag', e.target.value)}
+                  className="px-3 py-2 border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring bg-background text-foreground font-mono text-sm uppercase font-medium min-w-[100px]"
+                >
+                  {allTags.map((tag) => (
+                    <option key={tag} value={tag}>
+                      {tag.toUpperCase()}
+                    </option>
+                  ))}
+                </select>
+                {state.boxes.length > 1 && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => actions.removeBox(box.id)}
+                    className="p-2 h-8 w-8"
+                  >
+                    <X className="w-3 h-3" />
+                  </Button>
+                )}
+              </div>
+              
+              <textarea
+                value={box.content}
+                onChange={(e) => actions.updateBox(box.id, 'content', e.target.value)}
+                rows={3}
+                className="w-full px-3 py-2 border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring bg-background text-foreground text-sm resize-y"
+                placeholder={`Enter your ${box.tag} content here...`}
+              />
+            </div>
+          ))}
+
+          {state.boxes.length === 0 && (
+            <div className="text-center text-muted-foreground py-8">
+              <div className="text-sm font-medium mb-1">No prompt sections yet</div>
+              <div className="text-xs">Click "Add Section" to get started</div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Export Panel */}
+      <ExportPanel exportData={exportData} onExport={actions.exportPrompt} />
+    </div>
+  );
+} 

--- a/components/prompts/stats-panel.tsx
+++ b/components/prompts/stats-panel.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import React from 'react';
+import { BarChart3, FileText, Hash, Zap } from 'lucide-react';
+import type { PromptStats } from '../../types/prompt-builder';
+
+interface StatsPanelProps {
+  stats: PromptStats;
+}
+
+export function StatsPanel({ stats }: StatsPanelProps) {
+  return (
+    <div className="bg-card rounded-md border border-border p-3 space-y-3">
+      <h4 className="text-sm font-medium text-foreground flex items-center gap-2">
+        <BarChart3 className="w-4 h-4" />
+        Statistics
+      </h4>
+      
+      <div className="grid grid-cols-4 gap-2">
+        <div className="text-center">
+          <div className="flex items-center justify-center mb-1">
+            <Hash className="w-3 h-3 text-blue-600 dark:text-blue-400" />
+          </div>
+          <div className="text-sm font-medium text-foreground">
+            {stats.characterCount.toLocaleString()}
+          </div>
+          <div className="text-xs text-muted-foreground">Chars</div>
+        </div>
+
+        <div className="text-center">
+          <div className="flex items-center justify-center mb-1">
+            <FileText className="w-3 h-3 text-green-600 dark:text-green-400" />
+          </div>
+          <div className="text-sm font-medium text-foreground">
+            {stats.wordCount.toLocaleString()}
+          </div>
+          <div className="text-xs text-muted-foreground">Words</div>
+        </div>
+
+        <div className="text-center">
+          <div className="flex items-center justify-center mb-1">
+            <Zap className="w-3 h-3 text-purple-600 dark:text-purple-400" />
+          </div>
+          <div className="text-sm font-medium text-foreground">
+            {stats.estimatedTokens.toLocaleString()}
+          </div>
+          <div className="text-xs text-muted-foreground">Tokens</div>
+        </div>
+
+        <div className="text-center">
+          <div className="flex items-center justify-center mb-1">
+            <div className="w-1.5 h-1.5 bg-orange-600 dark:bg-orange-400 rounded-full"></div>
+          </div>
+          <div className="text-sm font-medium text-foreground">
+            {stats.boxCount}
+          </div>
+          <div className="text-xs text-muted-foreground">Boxes</div>
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/hooks/use-prompt-builder.ts
+++ b/hooks/use-prompt-builder.ts
@@ -1,0 +1,186 @@
+import { useState, useCallback, useEffect } from 'react';
+import type { 
+  PromptBox, 
+  PromptBuilderState, 
+  Position,
+  Connection,
+  ExportFormat 
+} from '../types/prompt-builder';
+import { DEFAULT_TAGS, STORAGE_KEY } from '../types/prompt-builder';
+
+const DEFAULT_BOXES: PromptBox[] = [
+  {
+    id: '1',
+    tag: 'persona',
+    content: 'You are a senior marketing copywriter who specializes in authentic, benefit-driven communication for overwhelmed professionals.',
+    position: { x: 0, y: 0, level: 0 }
+  },
+  {
+    id: '2',
+    tag: 'context',
+    content: 'Product: ZenFlow - a productivity app for the overwhelmed\nAudience: Busy professionals and students',
+    position: { x: 0, y: 0, level: 1 }
+  },
+  {
+    id: '3',
+    tag: 'task',
+    content: 'Create a compelling marketing email that will drive ZenFlow sign-ups.',
+    position: { x: 0, y: 0, level: 2 }
+  },
+  {
+    id: '4',
+    tag: 'output',
+    content: 'Deliver your response with a subject line, email body, and CTA text.',
+    position: { x: 0, y: 0, level: 3 }
+  }
+];
+
+const DEFAULT_CONNECTIONS: Connection[] = [];
+
+export function usePromptBuilder() {
+  const [state, setState] = useState<PromptBuilderState>({
+    boxes: DEFAULT_BOXES,
+    connections: DEFAULT_CONNECTIONS,
+    customTags: [],
+    stats: { characterCount: 0, wordCount: 0, estimatedTokens: 0, boxCount: 0 }
+  });
+
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        const savedState = JSON.parse(saved);
+        setState(prev => ({
+          ...prev,
+          ...savedState
+        }));
+      }
+    } catch (error) {
+      console.error('Failed to load saved state:', error);
+    }
+    setIsLoaded(true);
+  }, []);
+
+  // Save to localStorage whenever state changes
+  useEffect(() => {
+    if (!isLoaded) return;
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({
+        boxes: state.boxes,
+        connections: state.connections,
+        customTags: state.customTags
+      }));
+    } catch (error) {
+      console.error('Failed to save state:', error);
+    }
+  }, [state.boxes, state.connections, state.customTags, isLoaded]);
+
+  const updateBox = useCallback((id: string, field: 'tag' | 'content', value: string) => {
+    setState(prev => ({
+      ...prev,
+      boxes: prev.boxes.map(box =>
+        box.id === id ? { ...box, [field]: value } : box
+      )
+    }));
+  }, []);
+
+  const addBox = useCallback(() => {
+    const newId = Date.now().toString();
+    const level = state.boxes.length;
+    
+    const newBox: PromptBox = {
+      id: newId,
+      tag: DEFAULT_TAGS[0],
+      content: '',
+      position: { x: 0, y: 0, level }
+    };
+
+    setState(prev => ({
+      ...prev,
+      boxes: [...prev.boxes, newBox]
+    }));
+  }, [state.boxes]);
+
+  const removeBox = useCallback((id: string) => {
+    setState(prev => ({
+      ...prev,
+      boxes: prev.boxes.filter(box => box.id !== id)
+    }));
+  }, []);
+
+  const addCustomTag = useCallback((tag: string) => {
+    const cleanTag = tag.trim().toLowerCase().replace(/[^a-z0-9_-]/g, '_');
+    if (cleanTag && !state.customTags.includes(cleanTag) && !DEFAULT_TAGS.includes(cleanTag as any)) {
+      setState(prev => ({
+        ...prev,
+        customTags: [...prev.customTags, cleanTag]
+      }));
+    }
+  }, [state.customTags]);
+
+  const removeCustomTag = useCallback((tag: string) => {
+    setState(prev => ({
+      ...prev,
+      customTags: prev.customTags.filter(t => t !== tag),
+      boxes: prev.boxes.map(box =>
+        box.tag === tag ? { ...box, tag: DEFAULT_TAGS[0] } : box
+      )
+    }));
+  }, []);
+
+  const clearAllContent = useCallback(() => {
+    setState(prev => ({
+      ...prev,
+      boxes: prev.boxes.map(box => ({ ...box, content: '' }))
+    }));
+  }, []);
+
+  const resetToDefault = useCallback(() => {
+    setState({
+      boxes: DEFAULT_BOXES,
+      connections: DEFAULT_CONNECTIONS,
+      customTags: [],
+      stats: { characterCount: 0, wordCount: 0, estimatedTokens: 0, boxCount: 0 }
+    });
+    
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch (error) {
+      console.error('Failed to clear saved state:', error);
+    }
+  }, []);
+
+  const exportPrompt = useCallback((): ExportFormat => {
+    const xml = state.boxes
+      .filter(box => box.content.trim())
+      .map(box => `<${box.tag}>\n${box.content}\n</${box.tag}>`)
+      .join('\n\n');
+
+    const markdown = state.boxes
+      .filter(box => box.content.trim())
+      .map(box => `## ${box.tag.charAt(0).toUpperCase() + box.tag.slice(1)}\n\n${box.content}`)
+      .join('\n\n');
+
+    return { xml, markdown };
+  }, [state.boxes]);
+
+  const allTags = [...DEFAULT_TAGS, ...state.customTags];
+
+  return {
+    state,
+    allTags,
+    actions: {
+      updateBox,
+      addBox,
+      removeBox,
+      addCustomTag,
+      removeCustomTag,
+      clearAllContent,
+      resetToDefault,
+      exportPrompt
+    }
+  };
+} 

--- a/hooks/use-stats.ts
+++ b/hooks/use-stats.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+import type { PromptBox, PromptStats } from '../types/prompt-builder';
+
+export function useStats(boxes: PromptBox[]): PromptStats {
+  return useMemo(() => {
+    const allContent = boxes
+      .filter(box => box.content.trim())
+      .map(box => box.content)
+      .join(' ');
+
+    const characterCount = allContent.length;
+    const wordCount = allContent.trim() ? allContent.trim().split(/\s+/).length : 0;
+    
+    // Simple token estimation: ~4 characters per token (rough approximation)
+    const estimatedTokens = Math.ceil(characterCount / 4);
+    
+    const boxCount = boxes.filter(box => box.content.trim()).length;
+
+    return {
+      characterCount,
+      wordCount,
+      estimatedTokens,
+      boxCount
+    };
+  }, [boxes]);
+} 

--- a/types/prompt-builder.ts
+++ b/types/prompt-builder.ts
@@ -1,0 +1,52 @@
+export interface PromptBox {
+  id: string;
+  tag: string;
+  content: string;
+  position: Position;
+  parentId?: string;
+  children?: string[];
+  isCustomTag?: boolean;
+}
+
+export interface Position {
+  x: number;
+  y: number;
+  level: number; // Hierarchical level for tree structure
+}
+
+export interface Connection {
+  id: string;
+  parentId: string;
+  childId: string;
+  points: Point[];
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface PromptStats {
+  characterCount: number;
+  wordCount: number;
+  estimatedTokens: number;
+  boxCount: number;
+}
+
+export interface ExportFormat {
+  xml: string;
+  markdown: string;
+}
+
+export interface PromptBuilderState {
+  boxes: PromptBox[];
+  connections: Connection[];
+  customTags: string[];
+  selectedBoxId?: string;
+  stats: PromptStats;
+}
+
+export const DEFAULT_TAGS = ['persona', 'task', 'context', 'output'] as const;
+export type DefaultTag = typeof DEFAULT_TAGS[number];
+
+export const STORAGE_KEY = 'prompt-builder-state'; 


### PR DESCRIPTION
- Introduced a new PromptBuilderPage component for the visual prompt builder interface.
- Added PromptCanvas for managing prompt sections and connections.
- Implemented PromptBox for individual prompt sections with customizable tags and content.
- Created ConnectionLines to visually represent connections between prompt boxes.
- Developed ExportPanel for exporting prompts in XML and Markdown formats.
- Added StatsPanel to display statistics about the prompt content.
- Integrated hooks for managing prompt state and statistics.